### PR TITLE
Add web socket configuration

### DIFF
--- a/tickets-app-backend/src/main/java/com/umg/ticket_app_backend/config/SecurityConfig.java
+++ b/tickets-app-backend/src/main/java/com/umg/ticket_app_backend/config/SecurityConfig.java
@@ -29,8 +29,8 @@ public class SecurityConfig {
 
                     auth.requestMatchers("/api/v1/auth/token").permitAll();
                     auth.requestMatchers("/api/v1/auth/register").permitAll();
-
-                    auth.anyRequest().authenticated();
+                    
+                    auth.anyRequest().permitAll();
                 })
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .oauth2ResourceServer(oauth2 -> {

--- a/tickets-app-backend/src/main/java/com/umg/ticket_app_backend/config/WebSocketConfig.java
+++ b/tickets-app-backend/src/main/java/com/umg/ticket_app_backend/config/WebSocketConfig.java
@@ -1,0 +1,22 @@
+package com.umg.ticket_app_backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/v1");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/app");
+        registry.enableSimpleBroker("/topic");
+    }
+}

--- a/tickets-app-backend/src/main/java/com/umg/ticket_app_backend/controllers/TicketController.java
+++ b/tickets-app-backend/src/main/java/com/umg/ticket_app_backend/controllers/TicketController.java
@@ -1,0 +1,20 @@
+package com.umg.ticket_app_backend.controllers;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class TicketController {
+    @MessageMapping("/tickets")
+    @SendTo("/topic/tickets")
+    public Content getTickets(Message message) throws Exception {
+        return new Content(message.message());
+    }
+}
+
+record Message(String message) {
+}
+
+record Content(String content) {
+}


### PR DESCRIPTION
This pull request introduces significant changes to the backend of the `tickets-app` project, including updates to security configurations, the addition of WebSocket support, and a new controller for handling ticket-related WebSocket messages.

### Security Configuration Updates:
* Modified the `SecurityConfig` class to allow all requests (`auth.anyRequest().permitAll()`), relaxing the previous restriction that required authentication for all unspecified endpoints.

### WebSocket Support:
* Added a new `WebSocketConfig` class to enable WebSocket messaging, register the `/ws/v1` endpoint, and configure a simple message broker with `/app` as the application destination prefix and `/topic` as the topic prefix.

### WebSocket Message Handling:
* Introduced a `TicketController` class with a WebSocket endpoint to handle messages sent to `/tickets` and broadcast responses to `/topic/tickets`. This includes defining `Message` and `Content` record types for message handling.